### PR TITLE
Fix Fish

### DIFF
--- a/src/redgreen.alp
+++ b/src/redgreen.alp
@@ -114,7 +114,7 @@ state Bubble "o"
  is Steamy;
 
 state Fish "f"
-  to Air when not 1 Water,
+  to Air when not 1 Water and not 8 Fish,
   to Water when 4 Fish or 7 Water;
 
 state OnePebble "."


### PR DESCRIPTION
A fish surrounded on all sides by fish should not turn into air. This _might_ be better than reversing the instructions, but not sure.
